### PR TITLE
Add testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "node"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-# tsaproject# tsaproject
+[![Build Status](https://travis-ci.org/MBHS-Computer-Science-Association/tsaproject.svg?branch=master)](https://travis-ci.org/MBHS-Computer-Science-Association/tsaproject)
+
+# TSA-Software-Development-2017
 
 The master branch is being automatically deployed via Heroku [here](https://tsaproject2017.herokuapp.com).

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var app = require('express')();
 var http = require('http').Server(app);
 var io = require('socket.io')(http);
 
-var port = process.env.PORT || 80;
+var port = process.env.PORT || 3000;
 
 app.get(/^(.+)$/, function(req, res){
 	res.sendFile(__dirname + '/html' + req.params[0]);

--- a/package.json
+++ b/package.json
@@ -8,12 +8,17 @@
     "url": "https://github.com/MBHS-Computer-Science-Association/tsaproject.git"
   },
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "mocha"
   },
   "dependencies": {
     "express": "^4.14.0",
     "node-couchdb": "^1.1.0",
     "pg": "^6.1.0",
     "socket.io": "^1.7.2"
+  },
+  "devDependencies": {
+    "mocha": "*",
+    "chai": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "mocha"
+    "test": "istanbul cover mocha"
   },
   "dependencies": {
     "express": "^4.14.0",
@@ -18,7 +18,8 @@
     "socket.io": "^1.7.2"
   },
   "devDependencies": {
-    "mocha": "*",
-    "chai": "*"
+    "chai": "*",
+    "istanbul": "*",
+    "mocha": "*"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,7 @@
+var assert = require('chai').assert;
+
+describe('PostgreSQL Database', function() {
+    describe('get users function', function() {
+        it('should return all of the users in json');
+    });
+});


### PR DESCRIPTION
This would get out project using Mocha as a testing framework. Mocha will be used to run unit tests on things that we want to make sure work:

* inserting things into databases
* setting user statuses
* getting users by id
* getting things from databases

Some things that need to be added:
* modify package.json to include a test script
* allow ```npm start``` to be ran w/o sudo access (change port to above 1024)
* add .travis.yml

The ```.travis.yml``` file is for activating TravisCI, which is a continuous integration testing framework. It is a way to verify the stability of the application (based on our own test cases) every time that a commit is pushed a remote branch on GitHub.

I plan to write documentation about our testing in the TSA Portfolio.